### PR TITLE
Update README.md to include UCLan legal info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MazeMap is a wayfinding application used to help users find their way around cer
 
 <img width="1296" alt="Screenshot 2023-11-15 at 22 31 19" src="https://github.com/insert-professional-sounding-name-here/insert-professional-sounding-name-here.github.io/assets/20979204/83ee1ffb-89c8-490a-a24d-35691baebc49">
 
-## Maze-Data-API
+## Maze-Data-API & Legal
 Maze-Data-API is licensed under the Apache License 2.0.
 
 All API data is taken from the official MazeMap websites and GitHub Pages: 
@@ -24,6 +24,7 @@ MazeMap uses campus IDs to show campuses around the world, UCLan campus ID is 36
 
 <img width="1331" alt="Screenshot 2023-11-15 at 22 25 04" src="https://github.com/insert-professional-sounding-name-here/insert-professional-sounding-name-here.github.io/assets/20979204/4e579d30-1745-43f5-94a7-946534bf6d17">
 
-#### This repo is only for educational use for a university assignment and not to be used in a real-world situation or for commercial purposes. All copyrights reserved to their respective owners. MazeMap and related services are provided by MazeMap AS
+#### This repo is only for educational use for a university assignment and not to be used in a real-world situation or for commercial purposes. All copyrights reserved to their respective owners. MazeMap and related services are provided by MazeMap AS. The the UCLan logo is owned by the University of Central Lancashire.
 
-MazeMap Terms can be found at: https://www.mazemap.com/terms
+- MazeMap Terms can be found at: https://www.mazemap.com/terms
+- University of Central Lancashire copyrgiht information can be found at: https://www.uclan.ac.uk/legal/copyright


### PR DESCRIPTION
Updated README.md to include copyright info for UCLan logo (info used from [https://www.uclan.ac.uk/legal/copyright](url))